### PR TITLE
fix: Trim whitespace from vulnerability counts in scheduled scan

### DIFF
--- a/.github/workflows/scheduled-security-scan.yml
+++ b/.github/workflows/scheduled-security-scan.yml
@@ -72,17 +72,27 @@ jobs:
           trivy image --format sarif --output trivy-results.sarif --severity "${SEVERITY_THRESHOLD},CRITICAL" "$IMAGE" || true
           trivy image --format table --severity "${SEVERITY_THRESHOLD},CRITICAL" "$IMAGE" > scan-summary.txt || true
 
-          # Count vulnerabilities by severity
-          CRITICAL_COUNT=$(grep -c "CRITICAL" scan-summary.txt || echo 0)
-          HIGH_COUNT=$(grep -c "HIGH" scan-summary.txt || echo 0)
-          MEDIUM_COUNT=$(grep -c "MEDIUM" scan-summary.txt || echo 0)
+          # Count vulnerabilities by severity - ensure we get clean numbers
+          CRITICAL_COUNT=$(grep -c "CRITICAL" scan-summary.txt 2>/dev/null || echo "0")
+          HIGH_COUNT=$(grep -c "HIGH" scan-summary.txt 2>/dev/null || echo "0")
+          MEDIUM_COUNT=$(grep -c "MEDIUM" scan-summary.txt 2>/dev/null || echo "0")
+
+          # Trim any whitespace to ensure clean numeric values
+          CRITICAL_COUNT=$(echo "$CRITICAL_COUNT" | tr -d '[:space:]')
+          HIGH_COUNT=$(echo "$HIGH_COUNT" | tr -d '[:space:]')
+          MEDIUM_COUNT=$(echo "$MEDIUM_COUNT" | tr -d '[:space:]')
+
+          # Ensure counts are valid numbers, default to 0 if not
+          CRITICAL_COUNT=${CRITICAL_COUNT:-0}
+          HIGH_COUNT=${HIGH_COUNT:-0}
+          MEDIUM_COUNT=${MEDIUM_COUNT:-0}
 
           echo "critical_count=$CRITICAL_COUNT" >> $GITHUB_OUTPUT
           echo "high_count=$HIGH_COUNT" >> $GITHUB_OUTPUT
           echo "medium_count=$MEDIUM_COUNT" >> $GITHUB_OUTPUT
 
           # Determine if there are vulnerabilities
-          if [[ $CRITICAL_COUNT -gt 0 || $HIGH_COUNT -gt 0 ]]; then
+          if [[ "$CRITICAL_COUNT" -gt 0 || "$HIGH_COUNT" -gt 0 ]]; then
             echo "has_vulnerabilities=true" >> $GITHUB_OUTPUT
           else
             echo "has_vulnerabilities=false" >> $GITHUB_OUTPUT
@@ -96,7 +106,7 @@ jobs:
             echo "- **High**: $HIGH_COUNT"
             echo "- **Medium**: $MEDIUM_COUNT"
             echo ""
-            if [[ $CRITICAL_COUNT -gt 0 || $HIGH_COUNT -gt 0 ]]; then
+            if [[ "$CRITICAL_COUNT" -gt 0 || "$HIGH_COUNT" -gt 0 ]]; then
               echo "### Details:"
               echo '```'
               head -100 scan-summary.txt
@@ -187,7 +197,7 @@ jobs:
         continue-on-error: true
 
       - name: Send Discord notification for critical vulnerabilities
-        if: steps.scan.outputs.critical_count > 0
+        if: steps.scan.outputs.critical_count != '0' && steps.scan.outputs.critical_count != ''
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |


### PR DESCRIPTION
## Summary
- Fix 'syntax error in expression' error in scheduled security scan
- Add proper whitespace trimming to vulnerability counts
- Ensure counts are clean numeric values without newlines

## Problem
The scheduled security scan was failing with error:
```
[[: 0
0: syntax error in expression (error token is "0")
Error: Invalid format '0'
```

This happened because grep -c was returning counts with newlines when multiple Trivy runs were executed.

## Solution
1. Added whitespace trimming using `tr -d '[:space:]'` to ensure clean numbers
2. Added stderr redirection for grep commands
3. Added quotes around variables in numeric comparisons
4. Changed Discord notification condition to use string comparison
5. Added default value assignment to ensure valid numbers

## Test Plan
- [x] Workflow syntax is valid
- [x] Counts are properly trimmed and numeric
- [ ] Scheduled security scan runs successfully after merge