### PR TITLE
Fix: add SARIF category for automatic GitHub security alert closure

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -34,6 +34,7 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+          category: 'dependency-scan'
 
       - name: Run Trivy for PR comment
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Problem

GitHub Code Scanning alerts were not auto-closing after fixes because SARIF uploads lacked proper `category` fields.

**Root Cause:**
- SARIF uploads without `category` are tracked as separate "default" categories
- GitHub cannot match old alerts with new scans to auto-close them
- Result: Fixed vulnerabilities require manual "Won't Fix" dismissal

## Solution

Added `category: 'dependency-scan'` to Trivy SARIF upload in `.github/workflows/security-scan.yml`.

**Effect:**
- Future scans will use consistent category tracking
- Fixed vulnerabilities will automatically close alerts
- Manual dismissal no longer needed for resolved issues

## Changes

- Added `category: 'dependency-scan'` to dependency scan SARIF upload
- Container scan already had correct category

## Testing

- Workflow syntax valid
- SARIF upload will include category field
- Next security scan will establish baseline for auto-closure

## Note

Existing alerts need manual dismissal (already done). This fix prevents future manual work.