### PR TITLE
Fix Docker tagging: application tags generate only application tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,11 +84,10 @@ jobs:
             # Service version tags (v1.1.1 -> 1.1.1)
             type=semver,pattern={{version}}
 
-            # Application version tags (v2.0.1-application -> 2.0.1-application AND 2.0.1)
-            # When an application tag is pushed, generate BOTH the application tag and service version tag
-            # This ensures the same image has multiple tags without rebuilding
+            # Application version tags (v2.0.1-application -> 2.0.1-application ONLY)
+            # Application tags do NOT extract the base version
+            # Push separate service version tags for dual-tagging
             type=match,pattern=v(.+)-application,group=1,suffix=-application
-            type=match,pattern=v(.+)-application,group=1
 
             # Latest tag for main branch
             type=raw,value=latest,enable={{is_default_branch}}


### PR DESCRIPTION
### **User description**
Fixes incorrect dual-tagging where application tags extracted base version. Application tags now only generate -application suffixed tag. Push separate service version tags for proper dual-tagging.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes Docker tagging strategy for application releases

- Application tags now generate only `-application` suffixed tag

- Removes incorrect base version extraction from application tags

- Removes manual trigger tag generation from workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Publish Workflow"] -->|"Application tag<br/>v2.0.1-application"| B["Generate only<br/>2.0.1-application tag"]
  A -->|"Service tag<br/>v1.1.1"| C["Generate version tags<br/>1.1.1, 1.1, 1"]
  B -->|"No base version<br/>extraction"| D["Correct tagging"]
  C -->|"Separate service tags"| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Refactor Docker tagging strategy for application releases</code></dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Updated service version tags to only generate <code>{{version}}</code> pattern <br>(removed <code>{{major}}.{{minor}}</code> and <code>{{major}}</code> patterns)<br> <li> Added new application-specific tag matching using <code>type=match</code> pattern <br>to extract <code>-application</code> suffix only<br> <li> Added clarifying comments explaining that application tags do NOT <br>extract base versions<br> <li> Removed manual trigger tag generation (<code>workflow_dispatch</code> event <br>handling)</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/version-manager/pull/41/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

