### PR TITLE
Fix corrupted version.json - copy from infrastructure

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,1 +1,128 @@
-{"invalid": json}
+{
+  "application": {
+    "name": "figure-collector-services",
+    "version": "2.1.0",
+    "releaseDate": null,
+    "description": "Figure collection management application"
+  },
+  "services": {
+    "backend": {
+      "name": "figure-collector-backend",
+      "version": "2.1.0",
+      "repository": "figure-collector-backend",
+      "dockerImage": "backend:v2.1.0",
+      "ownedBy": "figure-collector",
+      "coupledWith": [
+        "frontend"
+      ]
+    },
+    "frontend": {
+      "name": "figure-collector-frontend",
+      "version": "2.1.0",
+      "repository": "figure-collector-frontend",
+      "dockerImage": "frontend:v2.1.0",
+      "ownedBy": "figure-collector",
+      "coupledWith": [
+        "backend"
+      ]
+    },
+    "scraper": {
+      "name": "page-scraper",
+      "version": "2.0.3",
+      "repository": "page-scraper",
+      "dockerImage": "scraper:v2.0.3",
+      "ownedBy": "platform",
+      "coupledWith": [],
+      "standalone": true,
+      "description": "Generic web scraping service"
+    },
+    "infrastructure": {
+      "name": "figure-collector-infra",
+      "version": "2.1.0",
+      "repository": "figure-collector-infra",
+      "ownedBy": "figure-collector",
+      "dockerImage": "infrastructure:v2.1.0"
+    },
+    "version-manager": {
+      "name": "version-manager",
+      "version": "1.1.4",
+      "repository": "version-manager",
+      "dockerImage": "version-manager:v1.1.4",
+      "ownedBy": "platform",
+      "coupledWith": []
+    },
+    "integration_tests": {
+      "name": "integration_tests",
+      "version": "1.0.2",
+      "repository": "integration_tests",
+      "dockerImage": "integration_tests:v1.0.2",
+      "ownedBy": "platform",
+      "coupledWith": []
+    }
+  },
+  "dependencies": {
+    "backend": {
+      "scraper": "^2.0.3"
+    },
+    "frontend": {
+      "backend": "^2.1.0"
+    }
+  },
+  "compatibility": {
+    "testedCombinations": [
+      {
+        "backend": "1.0.0",
+        "frontend": "1.0.0",
+        "scraper": "1.0.0",
+        "verified": "09-Aug-2025"
+      },
+      {
+        "backend": "1.1.0",
+        "frontend": "1.1.0",
+        "scraper": "1.1.0",
+        "verified": "01-Sep-2025"
+      },
+      {
+        "backend": "2.0.0",
+        "frontend": "2.0.0",
+        "scraper": "2.0.0",
+        "verified": "26-Oct-2025"
+      },
+      {
+        "backend": "2.0.1",
+        "frontend": "2.0.1",
+        "scraper": "2.0.1",
+        "verified": "26-Oct-2025"
+      },
+      {
+        "backend": "2.0.2",
+        "frontend": "2.0.2",
+        "scraper": "2.0.2",
+        "version-manager": "1.1.2",
+        "integration-tests": "1.0.2",
+        "verified": "30-Oct-2025",
+        "notes": "Simplified versioning strategy - removed dual-tagging"
+      },
+      {
+        "backend": "2.0.2",
+        "frontend": "2.0.2",
+        "scraper": "2.0.3",
+        "version-manager": "1.1.3",
+        "integration-tests": "1.0.2",
+        "infrastructure": "2.0.3",
+        "verified": "09-Nov-2025",
+        "notes": "Incremental updates: Scraper performance (6x faster), Version Manager compatibility tracking, Infrastructure documentation updates"
+      },
+      {
+        "backend": "2.1.0",
+        "frontend": "2.1.0",
+        "scraper": "2.0.3",
+        "version-manager": "1.1.4",
+        "integration-tests": "1.0.2",
+        "infrastructure": "2.1.0",
+        "verified": null,
+        "notes": "Pending v2.1.0 release: Backend adds Atlas Search (word wheel autocomplete + partial matching), Frontend adds dark mode theme support"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### **User description**
## Summary
Fixes corrupted version.json file that was causing version-manager container to crash on startup.

## Problem
version.json contained invalid placeholder content: `{"invalid": json}`

This caused version-manager to fail parsing the file and crash on startup.

## Solution
Copied correct version.json from figure-collector-infra repository, which contains the v2.1.0 service versions.

## Testing
- File parses correctly as valid JSON
- Contains all expected service version data
- Matches version.json in infrastructure repo

## Related
- Part of v2.1.0 release process


___

### **PR Type**
Bug fix


___

### **Description**
- Replaced corrupted `version.json` with valid JSON structure

- Restored complete service version metadata for v2.1.0 release

- Fixed version-manager container startup crash caused by invalid JSON

- Includes service definitions, dependencies, and compatibility matrix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Corrupted version.json<br/>invalid JSON"] -- "Replace with valid structure" --> B["Valid version.json<br/>v2.1.0 metadata"]
  B --> C["version-manager<br/>starts successfully"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.json</strong><dd><code>Restore valid version.json with complete service metadata</code></dd></summary>
<hr>

version.json

<ul><li>Replaced invalid placeholder <code>{"invalid": json}</code> with complete valid <br>JSON structure<br> <li> Added application metadata with v2.1.0 version information<br> <li> Defined six services with versions, repositories, and Docker images<br> <li> Included service dependencies and compatibility test matrix with seven <br>tested combinations</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/version-manager/pull/51/files#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354c">+128/-1</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

