### PR TITLE
Set v2.1.0 release date to 15-Nov-2025

### DIFF
--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
   "application": {
     "name": "figure-collector-services",
     "version": "2.1.0",
-    "releaseDate": null,
+    "releaseDate": "15-Nov-2025",
     "description": "Figure collection management application"
   },
   "services": {


### PR DESCRIPTION
### **User description**
## Summary
Synchronizes version.json fallback copy with infrastructure repo to set proper release date for v2.1.0.

## Context
Version-manager has a local version.json as a fallback when VERSION_JSON_PATH environment variable is not set (e.g., local development). This must stay in sync with the primary version.json in infrastructure repo.

## Changes
- version.json: Changed `"releaseDate": null` to `"releaseDate": "15-Nov-2025"`

## Related
- Infrastructure PR #23 (primary version.json update)
- Fixes configuration issue causing "unknown" release date display


___

### **PR Type**
Bug fix


___

### **Description**
- Update `version.json` fallback with v2.1.0 release date

- Synchronize local copy with infrastructure repository

- Fix "unknown" release date display issue


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["version.json<br/>releaseDate: null"] -- "Update to<br/>15-Nov-2025" --> B["version.json<br/>releaseDate: 15-Nov-2025"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.json</strong><dd><code>Update v2.1.0 release date configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

version.json

<ul><li>Changed <code>releaseDate</code> field from <code>null</code> to <code>"15-Nov-2025"</code><br> <li> Synchronizes fallback configuration with infrastructure repository<br> <li> Resolves release date display issue for v2.1.0</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/version-manager/pull/52/files#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

